### PR TITLE
Make Ycode a universal2 binary

### DIFF
--- a/Build.tool
+++ b/Build.tool
@@ -16,12 +16,22 @@ rm -rf "$appPath"
 mkdir -p "$appPath/Contents/MacOS"
 mkdir -p "$appPath/Contents/Resources"
 
-clang -fmodules -Wno-unused-getter-return-value -Wno-objc-missing-super-calls $frameworkFlags "$inPath" -o "$PWD/$name-amd64" -target x86_64-apple-macos10.12
-clang -fmodules -Wno-unused-getter-return-value -Wno-objc-missing-super-calls $frameworkFlags "$inPath" -o "$PWD/$name-arm64" -target arm64-apple-macos11
-lipo -create -output "$appPath/Contents/MacOS/$name" "$PWD/$name-amd64" "$PWD/$name-arm64"
+if [[ -z "$NO_UNIVERSAL" ]] ; then
+    clang -fmodules -Wno-unused-getter-return-value -Wno-objc-missing-super-calls $frameworkFlags "$inPath" -o "$PWD/$name-amd64" -target x86_64-apple-macos10.13
+    clang -fmodules -Wno-unused-getter-return-value -Wno-objc-missing-super-calls $frameworkFlags "$inPath" -o "$PWD/$name-arm64" -target arm64-apple-macos11
+    lipo -create -output "$appPath/Contents/MacOS/$name" "$PWD/$name-amd64" "$PWD/$name-arm64"
+    
+    rm -rf "$PWD/$name-amd64"
+    rm -rf "$PWD/$name-arm64"
 
-rm -rf "$PWD/$name-amd64"
-rm -rf "$PWD/$name-arm64"
+else
+    echo "Compatibility mode enabled!"
+    if [[ $(uname -m) != "arm64" ]]; then
+        clang -fmodules -Wno-unused-getter-return-value -Wno-objc-missing-super-calls $frameworkFlags "$inPath" -o "$appPath/Contents/MacOS/$name" -target x86_64-apple-macos10.13
+    else
+        clang -fmodules -Wno-unused-getter-return-value -Wno-objc-missing-super-calls $frameworkFlags "$inPath" -o "$appPath/Contents/MacOS/$name" -target arm64-apple-macos11
+    fi
+fi
 
 plistPath="$appPath/Contents/Info.plist"
 defaults write "$plistPath" CFBundleExecutable "$name"

--- a/Build.tool
+++ b/Build.tool
@@ -16,7 +16,12 @@ rm -rf "$appPath"
 mkdir -p "$appPath/Contents/MacOS"
 mkdir -p "$appPath/Contents/Resources"
 
-clang -fmodules -Wno-unused-getter-return-value -Wno-objc-missing-super-calls $frameworkFlags "$inPath" -o "$appPath/Contents/MacOS/$name"
+clang -fmodules -Wno-unused-getter-return-value -Wno-objc-missing-super-calls $frameworkFlags "$inPath" -o "$PWD/$name-amd64" -target x86_64-apple-macos10.12
+clang -fmodules -Wno-unused-getter-return-value -Wno-objc-missing-super-calls $frameworkFlags "$inPath" -o "$PWD/$name-arm64" -target arm64-apple-macos11
+lipo -create -output "$appPath/Contents/MacOS/$name" "$PWD/$name-amd64" "$PWD/$name-arm64"
+
+rm -rf "$PWD/$name-amd64"
+rm -rf "$PWD/$name-arm64"
 
 plistPath="$appPath/Contents/Info.plist"
 defaults write "$plistPath" CFBundleExecutable "$name"


### PR DESCRIPTION
This PR updates Build.tool to support building Ycode as a universal binary. It's enabled by default, but can be disabled with the `NO_UNIVERSAL` environment variable set to any variable before building the app.

This PR also makes it so that Ycode deploys to macOS 10.13 on Intel, and macOS 11 on Apple silicon.

:3 